### PR TITLE
대칭게임 레벨하락 기능 추가

### DIFF
--- a/Assets/Scene/Game/Pollution/Kitchen_p.unity
+++ b/Assets/Scene/Game/Pollution/Kitchen_p.unity
@@ -2991,7 +2991,7 @@ Canvas:
   m_OverridePixelPerfect: 0
   m_SortingBucketNormalizedSize: 0
   m_AdditionalShaderChannelsFlag: 0
-  m_SortingLayerID: 0
+  m_SortingLayerID: -950258435
   m_SortingOrder: 1
   m_TargetDisplay: 0
 --- !u!224 &1007803589

--- a/Assets/Scene/Game/Symmetry/ResultSceneController.cs
+++ b/Assets/Scene/Game/Symmetry/ResultSceneController.cs
@@ -115,6 +115,7 @@ public class ResultSceneController : MonoBehaviour
         newGameData = PlaySceneController.myGameData;
 
         myScore = getScore(newGameData);
+        LevelDownController(newGameData.diff, myScore);
         scoreText.text = myScore + "";
         lowLevel.text = "Lv" + newGameData.diff;
         if(newGameData.diff != 3)
@@ -134,6 +135,24 @@ public class ResultSceneController : MonoBehaviour
         LoginController.myPlayData.SymmetryPlay++; // 플레이 횟수
 
         WriteDB(); // firebase에 저장하기
+    }
+
+    public void LevelDownController(int diff,int score)
+    {
+        if(diff == 2)
+        {
+            if(score < 3000)
+            {
+                LevelDownWriteDB();
+            }
+        }
+        else if(diff == 3)
+        {
+            if(score < 6000)
+            {
+                LevelDownWriteDB();
+            }
+        }
     }
 
     // 점수 설정
@@ -238,6 +257,15 @@ public class ResultSceneController : MonoBehaviour
         if(LoginController.myDiffData.SymmetryGameDifficulty != 3)
         {
             LoginController.myDiffData.SymmetryGameDifficulty++;
+            reference.Child(LoginController.myID).Child("SymmetryGameDifficulty").SetValueAsync(LoginController.myDiffData.SymmetryGameDifficulty);
+        }
+    }
+
+    public void LevelDownWriteDB()
+    {
+        if(LoginController.myDiffData.SymmetryGameDifficulty != 1)
+        {
+            LoginController.myDiffData.SymmetryGameDifficulty--;
             reference.Child(LoginController.myID).Child("SymmetryGameDifficulty").SetValueAsync(LoginController.myDiffData.SymmetryGameDifficulty);
         }
     }


### PR DESCRIPTION
1. 대칭게임 레벨별 스코어에 미치지 못할 경우 레벨이 하락하는 기능 추가 (Lv2, 3000점 : Lv3, 6000점)